### PR TITLE
UI: Added visible styled scrollbars for result grid

### DIFF
--- a/client/mysql-gui-client/src/app/pages/resultgrid/resultgrid.component.html
+++ b/client/mysql-gui-client/src/app/pages/resultgrid/resultgrid.component.html
@@ -60,9 +60,11 @@
     >
         <p class="text-lg font-semibold">The query was executed successfully, but there are no rows to display.</p>
     </div>
+
+    <!-- Corrected scrollable grid -->
     <div
         *ngIf="!isLoading && !errorMessage && rows.length > 0"
-        class="h-96 overflow-y-auto [&::-webkit-scrollbar]:hidden"
+        class="h-96 overflow-y-auto result-grid"
     >
         <table class="h-20 min-w-max border-collapse border border-gray-300">
             <thead class="sticky top-0 z-10 bg-gray-200">


### PR DESCRIPTION

This PR fixes the issue where scrollbars were hidden in the result grid. Now, when query results overflow vertically, the scrollbars will appear.

Changes
- Removed the Tailwind class `[&::-webkit-scrollbar]:hidden` that was hiding scrollbars.
- Added `result-grid` class to the scrollable div for easier styling in the future.

